### PR TITLE
Added skeletons from UML

### DIFF
--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ClaimDataExporter.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ClaimDataExporter.java
@@ -1,0 +1,6 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+// FIXME Changed from interface to abstract
+abstract public class ClaimDataExporter {
+	abstract public void export(ExpenseClaim claim);
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/Destination.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/Destination.java
@@ -1,0 +1,21 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public class Destination {
+	private String name;
+	private String reasonForTravel;
+	
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getReasonForTravel() {
+		return reasonForTravel;
+	}
+	public void setReasonForTravel(String reasonForTravel) {
+		this.reasonForTravel = reasonForTravel;
+	}
+	
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaim.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaim.java
@@ -1,0 +1,56 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+public class ExpenseClaim implements IModel {
+	public enum Status {
+		IN_PROGRESS, SUBMITTED, RETURNED, APPROVED
+	}
+
+	private String name;
+	private Date startDate;
+	private Date endDate;
+	private Status status;
+	
+	private ArrayList<IView> views; // FIXME: Not initialized
+	
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public Date getStartDate() {
+		return startDate;
+	}
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+	public Date getEndDate() {
+		return endDate;
+	}
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+	public Status getStatus() {
+		return status;
+	}
+	public void setStatus(Status status) {
+		this.status = status;
+	}
+	@Override
+	public void addView(IView<IModel> v) {
+		views.add(v);
+	}
+	@Override
+	public void removeView(IView<IModel> v) {
+		views.remove(v);
+	}
+	@Override
+	public void notifyViews() {
+		for (IView v : views) {
+			v.update(this);
+		}
+	}
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaim.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaim.java
@@ -12,6 +12,7 @@ public class ExpenseClaim implements IModel {
 	private Date startDate;
 	private Date endDate;
 	private Status status;
+	private Tag tag;
 	
 	private ArrayList<IView> views; // FIXME: Not initialized
 	
@@ -38,6 +39,12 @@ public class ExpenseClaim implements IModel {
 	}
 	public void setStatus(Status status) {
 		this.status = status;
+	}
+	public Tag getTag() {
+		return tag;
+	}
+	public void setTag(Tag tag) {
+		this.tag = tag;
 	}
 	@Override
 	public void addView(IView<IModel> v) {

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaimController.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaimController.java
@@ -1,0 +1,39 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+import java.util.ArrayList;
+
+public class ExpenseClaimController {
+	private ExpenseClaimList claimlist;
+
+	public ExpenseClaimController() {
+		super();
+		this.claimlist = new ExpenseClaimList();
+	}
+	public ExpenseClaimController(ExpenseClaimList claimlist) {
+		super();
+		this.claimlist = claimlist;
+	}
+	
+	// FIXME Where does this come from?
+	public ArrayList<ExpenseClaim> getExpenseClaimList() {
+		return null;
+	}
+	
+	// FIXME What does this do? UML doesn't specify what or how.
+	public void saveExpenseClaim(ExpenseClaim claim) {
+		
+	}
+	
+	// Renamed from "addExpenseClaimToList" ???
+	public void addExpenseClaim(ExpenseClaim claim) {
+		claimlist.addClaim(claim);
+	}
+	
+	// FIXME wtf does "addExpenseClaimToList(ExpenseClaimList)" mean??
+	// How does it use an ExpenseClaimList??
+	// Same with editExpenseClaim(...);
+	
+	public void editExpenseClaim(ExpenseClaim claim) {
+		claimlist.editClaim(claim);
+	}
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaimList.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseClaimList.java
@@ -1,0 +1,50 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+import java.util.ArrayList;
+
+public class ExpenseClaimList implements IModel {
+	private ArrayList<ExpenseClaim> claims;
+	
+	private ArrayList<IView> views; // FIXME: Not initialized
+	/* FIXME
+	 * UML says 0..* ExpenseClaimList's are composed of
+	 * 			1 ExpenseClaimController,
+	 * and that 1 ExpenseClaimList is composed of ? Expense Claims
+	 */
+	
+	// FIXME UML says this takes no args
+	public ExpenseClaim getClaim(int index) {
+		return claims.get(index);
+	}
+	
+	public void addClaim(ExpenseClaim claim) {
+		claims.add(claim);
+	}
+	
+	// FIXME What does this do?
+	// Assuming it takes the argument claim.
+	public void editClaim(ExpenseClaim claim) {
+		return;
+	}
+	
+	public void removeClaim(ExpenseClaim claim) {
+		claims.remove(claim);
+	}
+
+	@Override
+	public void addView(IView<IModel> v) {
+		views.add(v);
+	}
+
+	@Override
+	public void removeView(IView<IModel> v) {
+		views.remove(v);
+	}
+
+	@Override
+	public void notifyViews() {
+		for (IView v : views) {
+			v.update(this);
+		}
+	}
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseItem.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/ExpenseItem.java
@@ -1,0 +1,84 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+import android.graphics.Bitmap;
+
+public class ExpenseItem implements IModel {
+	
+	public Date date;
+	public String description;
+	public String category;
+	public double amountSpent;	//FIXME doubles are bad for currencies
+	public String currency;
+	public Bitmap reciptPhoto;
+	
+	private ArrayList<IView> views;
+	
+	public void setDate(Date date){
+		this.date = date;
+	}
+	
+	public Date getDate(){
+		return this.date;
+	}
+	
+	public void setDescription(String description){
+		this.description = description;
+	}
+	
+	public String getDescription(){
+		return this.description;
+	}
+	
+	public void setCategory(String category){
+		this.category = category;
+	}
+
+	public String getCategory(){
+		return this.category;
+	}
+	
+	public void setAmountSpent(double amountSpent){
+		this.amountSpent = amountSpent;
+	}
+	
+	public double getAmountSpent(){
+		return this.amountSpent;
+	}
+	
+	public void setCurrency(String currency){
+		this.currency = currency;
+	}
+	
+	public String getCurrency(){
+		return this.currency;
+	}
+	
+	public void setReciptPhoto(Bitmap photo) {
+		this.reciptPhoto = photo;
+	}
+	
+	public Bitmap getReciptPhoto(){
+		return this.reciptPhoto;
+	}
+
+	@Override
+	public void addView(IView<IModel> v) {
+		views.add(v);
+	}
+
+	@Override
+	public void removeView(IView<IModel> v) {
+		views.remove(v);
+	}
+
+	@Override
+	public void notifyViews() {
+		for (IView v : views) {
+			v.update(this);
+		}
+	}
+	
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/IModel.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/IModel.java
@@ -1,0 +1,8 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public interface IModel {
+	// FIXME generic types are evil and cause infinity warnings.
+	public void addView(IView<IModel> v);
+	public void removeView(IView<IModel> v);
+	public void notifyViews();
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/IView.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/IView.java
@@ -1,0 +1,5 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public interface IView<M extends IModel> {
+	public void update(M m);
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/Tag.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/Tag.java
@@ -1,0 +1,17 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public class Tag {
+	private String value;
+	
+	public Tag(String s) {
+		this.value = s;
+	}
+	
+	public String getValue() {
+		return value;
+	}
+	
+	public boolean equals(Tag other) {
+		return this.getValue().equals(other.getValue());
+	}
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/TagController.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/TagController.java
@@ -1,0 +1,19 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public class TagController {
+	private TagList list;
+	
+	public TagController() {
+		list = new TagList();
+	}
+	public TagController(TagList list) {
+		this.list = list;
+	}
+	
+	public void addTag(String s) {
+		list.addTag(s);
+	}
+	public void removeTag(String s) {
+		list.removeTag(s);
+	}
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/TagList.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/TagList.java
@@ -1,0 +1,51 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+import java.util.ArrayList;
+
+public class TagList implements IModel {
+	private ArrayList<Tag> tags;
+	
+	private ArrayList<IView> views; 
+	
+	public ArrayList<Tag> getTags() {
+		return tags;
+	}
+	
+	/* FIXME
+	 * UML says addTag(String) and removeTag(String).
+	 * Should this go into the TagController object?
+	 */
+	public void addTag(Tag t) {
+		tags.add(t);
+	}
+	public void addTag(String s) {
+		tags.add(new Tag(s));
+	}
+	
+	public void removeTag(Tag t) {
+		tags.remove(t);
+	}
+
+	public void removeTag(String s) {
+		tags.remove(new Tag(s));
+	}
+
+	@Override
+	public void addView(IView<IModel> v) {
+		views.add(v);
+	}
+
+	@Override
+	public void removeView(IView<IModel> v) {
+		// FIXME May crash if v is not in views
+		views.remove(v);
+	}
+
+	@Override
+	public void notifyViews() {
+		for (IView v : views) {
+			v.update(this);
+		}
+	}
+	
+}

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/WebServiceExporter.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/WebServiceExporter.java
@@ -1,0 +1,10 @@
+package ca.ualberta.cs.shinyexpensetracker;
+
+public class WebServiceExporter extends ClaimDataExporter {
+
+	@Override
+	public void export(ExpenseClaim claim) {
+		// TODO Auto-generated method stub
+	}
+
+}


### PR DESCRIPTION
This is all the skeleton code that I could gather from the UML, excluding Activities. There were a few errors in the UML and there are definitely going to be errors in what I've written (ex. from initialization, constructors, vague interpretations, etc); there are numerous "FIXME" tags in the comments that will need to be addressed. For now, I think this should be a good enough starting point that we can start work on other major things.

For ExpenseClaim and ExpenseItem, I copied the code that was in the github repo already. In the future, we should refer to our JUnit tests for how we want to interact with these classes and objects.