### PR TITLE
173 Fixed hanging test.

### DIFF
--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/activities/GeolocationViewActivity.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/activities/GeolocationViewActivity.java
@@ -25,7 +25,9 @@
 package ca.ualberta.cs.shinyexpensetracker.activities;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationListener;
@@ -34,7 +36,6 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Toast;
 import ca.ualberta.cs.shinyexpensetracker.R;
 import ca.ualberta.cs.shinyexpensetracker.models.Coordinate;
 
@@ -43,9 +44,10 @@ public class GeolocationViewActivity extends Activity {
 	private LocationManager lm;
 	private Coordinate coordinates = new Coordinate();
 	private Coordinate coordinatesUpdating = new Coordinate();
-	
+
 	public static final int SET_GEOLOCATION = 1;
 	private static final Coordinate NORTH_KOREA_CONCENTRATION_CAMP_COORDINATES = new Coordinate(39.03808, 125.7296);
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -80,26 +82,47 @@ public class GeolocationViewActivity extends Activity {
 		}
 		return super.onOptionsItemSelected(item);
 	}
-	
+
 	/**
-	 * On click of Set Automatically Using GPS, get the constantly updating coordinate values
-	 * and save them to the "release version" values
+	 * On click of Set Automatically Using GPS, get the constantly updating
+	 * coordinate values and save them to the "release version" values
 	 */
 	public void clickSetGeolocationAutomatically(View v) {
-		
+
 		coordinates.setLatitude(coordinatesUpdating.getLatitude());
 		coordinates.setLongitude(coordinatesUpdating.getLongitude());
-		if (lm.getLastKnownLocation(LocationManager.GPS_PROVIDER) == null) {
-			Toast.makeText(this, "GPS positioning not enabled.\nEnable GPS positioning or enter the coordiantes manually using the map", Toast.LENGTH_LONG).show();
-		}
-		else {
+		if (!lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+			buildAlertMessageNoGps();
+		} else {
 			returnCoordinatesToParentActivity();
 		}
 	}
-	
+
 	/**
-	 * On click of Set Geolocation Using Map, navigate to the MapViewActivity to let the user
-	 * choose geolocation on an interactive map
+	 * Alert no GPS signal found Source:
+	 * http://stackoverflow.com/questions/843675
+	 * /how-do-i-find-out-if-the-gps-of-an-android-device-is-enabled Apr 5, 2015
+	 */
+	private void buildAlertMessageNoGps() {
+		final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		builder
+				.setMessage("Your GPS seems to be disabled, do you want to enable it?").setCancelable(false)
+				.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+					public void onClick(final DialogInterface dialog, final int id) {
+						startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+					}
+				}).setNegativeButton("No", new DialogInterface.OnClickListener() {
+					public void onClick(final DialogInterface dialog, final int id) {
+						dialog.cancel();
+					}
+				});
+		final AlertDialog alert = builder.create();
+		alert.show();
+	}
+
+	/**
+	 * On click of Set Geolocation Using Map, navigate to the MapViewActivity to
+	 * let the user choose geolocation on an interactive map
 	 */
 	public void clickSetGeolocationUsingMap(View v) {
 		Intent mapViewIntent = new Intent(GeolocationViewActivity.this, MapViewActivity.class);
@@ -108,10 +131,10 @@ public class GeolocationViewActivity extends Activity {
 		mapViewIntent.putExtra("requestCode", SET_GEOLOCATION);
 		startActivityForResult(mapViewIntent, SET_GEOLOCATION);
 	}
-	
+
 	/**
-	 * Accept result from the map activity and immediately return it
-	 * to the parent activity
+	 * Accept result from the map activity and immediately return it to the
+	 * parent activity
 	 */
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -119,16 +142,16 @@ public class GeolocationViewActivity extends Activity {
 		lm.removeUpdates(listener);
 		if (resultCode == RESULT_OK) {
 			double latitude = data.getDoubleExtra("latitude", NORTH_KOREA_CONCENTRATION_CAMP_COORDINATES.getLatitude());
-			double longitude = data.getDoubleExtra("longitude", NORTH_KOREA_CONCENTRATION_CAMP_COORDINATES.getLongitude());
+			double longitude = data.getDoubleExtra("longitude",
+					NORTH_KOREA_CONCENTRATION_CAMP_COORDINATES.getLongitude());
 			coordinates.setLatitude(latitude);
 			coordinates.setLongitude(longitude);
 			returnCoordinatesToParentActivity();
-		}
-		else {
+		} else {
 			lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1000, 1, listener);
 		}
 	}
-	
+
 	/**
 	 * Finish the activity and send saved coordinates to the parent activity
 	 */
@@ -139,31 +162,37 @@ public class GeolocationViewActivity extends Activity {
 		setResult(ExpenseClaimListActivity.RESULT_OK, geolocationResultIntent);
 		finish();
 	}
-	
+
 	/**
 	 * Location listener that fires every time a location update is requested.
-	 * Updates geolocation based on info from the GPS mdoule until 
-	 * the listener is unbound from its location manager.
-	 * The listener updates a different set of coordinate values because we don't want
-	 * to update the TextView every time that the location is changed and we do want to save
-	 * geolocation retrieved from the MapViewActivity  
+	 * Updates geolocation based on info from the GPS mdoule until the listener
+	 * is unbound from its location manager. The listener updates a different
+	 * set of coordinate values because we don't want to update the TextView
+	 * every time that the location is changed and we do want to save
+	 * geolocation retrieved from the MapViewActivity
 	 */
 	private final LocationListener listener = new LocationListener() {
 		/*
-		 * Adapted from joshua2ua's fork of MockLocationTester, file MockLocationTesterActivity.java on April 2, 2015
-		 * source at: https://github.com/joshua2ua/MockLocationTester/blob/master/src/ualberta/cmput301/mocklocationtester/MockLocationTesterActivity.java
+		 * Adapted from joshua2ua's fork of MockLocationTester, file
+		 * MockLocationTesterActivity.java on April 2, 2015 source at:
+		 * https://github
+		 * .com/joshua2ua/MockLocationTester/blob/master/src/ualberta
+		 * /cmput301/mocklocationtester/MockLocationTesterActivity.java
 		 */
-		public void onLocationChanged (Location location) {
+		public void onLocationChanged(Location location) {
 			if (location != null) {
 				coordinatesUpdating.setLatitude(location.getLatitude());
 				coordinatesUpdating.setLongitude(location.getLongitude());
 			}
 		}
-		public void onProviderDisabled (String provider) {
+
+		public void onProviderDisabled(String provider) {
 		}
-		public void onProviderEnabled (String provider) {
+
+		public void onProviderEnabled(String provider) {
 		}
-		public void onStatusChanged (String provider, int status, Bundle extras) {
+
+		public void onStatusChanged(String provider, int status, Bundle extras) {
 		}
 	};
 }

--- a/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/framework/Application.java
+++ b/ShinyExpenseTracker/src/ca/ualberta/cs/shinyexpensetracker/framework/Application.java
@@ -101,7 +101,7 @@ public class Application extends android.app.Application {
 	 * @param state
 	 */
 	public static void setUserType(Type type) {
-		user.setUserType(type);
+		getUser().setUserType(type);
 	}
 	
 	/**
@@ -109,6 +109,6 @@ public class Application extends android.app.Application {
 	 * @return
 	 */
 	public static Type getUserType() {
-		return user.getUserType();
+		return getUser().getUserType();
 	}
 }

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddExpenseClaimTests.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddExpenseClaimTests.java
@@ -18,6 +18,7 @@ import ca.ualberta.cs.shinyexpensetracker.activities.TabbedSummaryActivity;
 import ca.ualberta.cs.shinyexpensetracker.framework.Application;
 import ca.ualberta.cs.shinyexpensetracker.framework.ExpenseClaimController;
 import ca.ualberta.cs.shinyexpensetracker.models.ExpenseClaim;
+import ca.ualberta.cs.shinyexpensetracker.models.User.Type;
 import ca.ualberta.cs.shinyexpensetracker.test.mocks.MockExpenseClaimListPersister;
 
 /**
@@ -45,6 +46,7 @@ public class AddExpenseClaimTests extends
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
+		Application.setUserType(Type.Claimant);
 
 		controller = new ExpenseClaimController(
 				new MockExpenseClaimListPersister());
@@ -110,7 +112,7 @@ public class AddExpenseClaimTests extends
 	public void testThatInputtingAnEndDateThatIsAfterTheStartDateIsValid() {
 
 		ActivityMonitor monitor = instrumentation.addMonitor(
-				TabbedSummaryActivity.class.getName(), null, false);
+				TabbedSummaryClaimantActivity.class.getName(), null, false);
 
 
 		activity.runOnUiThread(new Runnable() {
@@ -124,7 +126,7 @@ public class AddExpenseClaimTests extends
 		});
 
 		instrumentation.waitForIdleSync();
-		TabbedSummaryActivity nextActivity = (TabbedSummaryActivity) instrumentation
+		TabbedSummaryActivity nextActivity = (TabbedSummaryClaimantActivity) instrumentation
 				.waitForMonitor(monitor);
 		assertNotNull("Next activity not started", nextActivity);
 
@@ -135,7 +137,7 @@ public class AddExpenseClaimTests extends
 	public void testThatTappingDoneWhileCreatingNewExpenseClaimCreatesANewExpenseClaim()
 			throws ParseException {
 		ActivityMonitor monitor = instrumentation.addMonitor(
-				TabbedSummaryActivity.class.getName(), null, false);
+				TabbedSummaryClaimantActivity.class.getName(), null, false);
 
 		final String claimName = "URoma";
 		activity.runOnUiThread(new Runnable() {
@@ -153,7 +155,7 @@ public class AddExpenseClaimTests extends
 
 		instrumentation.waitForIdleSync();
 
-		TabbedSummaryActivity nextActivity = (TabbedSummaryActivity) instrumentation
+		TabbedSummaryActivity nextActivity = (TabbedSummaryClaimantActivity) instrumentation
 				.waitForMonitor(monitor);
 		assertNotNull("Next activity not started", nextActivity);
 

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddExpenseItemTests.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddExpenseItemTests.java
@@ -222,6 +222,7 @@ public class AddExpenseItemTests extends ActivityInstrumentationTestCase2<Expens
 				doneButton.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 
 		assertNotNull("no name dialog", activity.alertDialog);
 		assertTrue("Name dialog is not showing", activity.alertDialog.isShowing());
@@ -238,6 +239,7 @@ public class AddExpenseItemTests extends ActivityInstrumentationTestCase2<Expens
 				doneButton.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 
 		assertNotNull("no date dialog", activity.alertDialog);
 		assertTrue("Date dialog is not showing", activity.alertDialog.isShowing());
@@ -254,6 +256,7 @@ public class AddExpenseItemTests extends ActivityInstrumentationTestCase2<Expens
 				doneButton.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 
 		assertNotNull("no amount spent dialog", activity.alertDialog);
 		assertTrue("Dialog amount spent is not showing", activity.alertDialog.isShowing());

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddTagToExpenseClaimActivityTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/AddTagToExpenseClaimActivityTest.java
@@ -134,6 +134,7 @@ public class AddTagToExpenseClaimActivityTest extends
 				done.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 	}
 	
 }

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ClaimSummaryFragmentTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ClaimSummaryFragmentTest.java
@@ -164,6 +164,7 @@ public class ClaimSummaryFragmentTest extends
 			}
 
 		});
+		getInstrumentation().waitForIdleSync();
 		TextView noExpenses = (TextView) frag.getView().findViewById(R.id.noExpensesTextView);
 		assertEquals("No Expenses not shown", "No Expenses", noExpenses.getText().toString());
 	}
@@ -179,6 +180,7 @@ public class ClaimSummaryFragmentTest extends
 				frag.setClaimInfo(frag.getView());
 			}
 		});
+		getInstrumentation().waitForIdleSync();
 		TextView tags = (TextView) frag.getView().findViewById(R.id.claimTagsTextView);
 		assertEquals("Tags showns", "Tags: ", tags.getText().toString());
 	}

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/DestinationListFragmentTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/DestinationListFragmentTest.java
@@ -186,6 +186,7 @@ public class DestinationListFragmentTest extends
 					frag.deleteDestinationAt(0);
 				}
 			});
+			getInstrumentation().waitForIdleSync();
 		}
 		
 		// Check that the controller removed an item (UI -> Model)

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ExpenseItemListFragmentTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ExpenseItemListFragmentTest.java
@@ -175,6 +175,7 @@ public class ExpenseItemListFragmentTest extends
 					frag.deleteExpenseAt(0);
 				}
 			});
+			getInstrumentation().waitForIdleSync();
 		}
 		
 		// Check that the controller removed an item (UI -> Model)

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/GeolocationViewTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/GeolocationViewTest.java
@@ -71,6 +71,7 @@ public class GeolocationViewTest extends
 				setGeolocationAutomatically.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 		assertTrue("did not finish activity", geolocationViewActivity.isFinishing());
 	}
 	
@@ -84,6 +85,7 @@ public class GeolocationViewTest extends
 				setGeolocationUsingMap.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 		assertEquals("MapViewActivity is not launched", am.getHits(), 1);
 	}
 }

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/LoginAsApproverOrClaimantActivityTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/LoginAsApproverOrClaimantActivityTest.java
@@ -47,6 +47,7 @@ public class LoginAsApproverOrClaimantActivityTest extends
 
 			}
 		});
+		getInstrumentation().waitForIdleSync();
 
 		// Get the view expense claims activity
 		final ExpenseClaimListActivity expenses = (ExpenseClaimListActivity) getInstrumentation()
@@ -89,6 +90,7 @@ public class LoginAsApproverOrClaimantActivityTest extends
 						.performClick();
 			}
 		});
+		getInstrumentation().waitForIdleSync();
 
 		// Get the view expense claims activity
 		final ExpenseClaimListActivity expenses = (ExpenseClaimListActivity) getInstrumentation()

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ManageTagActivityTests.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ManageTagActivityTests.java
@@ -37,6 +37,8 @@ public class ManageTagActivityTests extends ActivityInstrumentationTestCase2<Man
 		instrumentation = getInstrumentation();
 		manageTagsListView = (ListView) activity.findViewById(ca.ualberta.cs.shinyexpensetracker.R.id.listViewManageTags);
 		done = (Button) activity.findViewById(ca.ualberta.cs.shinyexpensetracker.R.id.doneButtonManageTags);
+		
+		instrumentation.waitForIdleSync();
 	}
 	
 	public void testAddDialogShows(){
@@ -45,8 +47,6 @@ public class ManageTagActivityTests extends ActivityInstrumentationTestCase2<Man
 		AlertDialog dialog = ManageTagActivity.getDialog();
 		assertTrue(dialog.isShowing());
 	}
-
-	
 
 	public void testAddingToDialog(){
 		Tag tag = new Tag("TEST");
@@ -125,19 +125,18 @@ public class ManageTagActivityTests extends ActivityInstrumentationTestCase2<Man
 	}
 
 	//Adds a tag through the add menu button and dialog
-	private void addTagThroughDialog(String tagName) {
+	private void addTagThroughDialog(final String tagName) {
 		clickAddTagsButton();
 		AlertDialog dialog = ManageTagActivity.getDialog();
 		
-		EditText dialogEditText = (EditText) dialog.findViewById(R.id.EditTextDialogTag);
+		final EditText dialogEditText = (EditText) dialog.findViewById(R.id.EditTextDialogTag);
 		final Button dialogPostiveButton = (Button) dialog.getButton(DialogInterface.BUTTON_POSITIVE);
-		
-		dialogEditText.setText(tagName);
 		
 		instrumentation.runOnMainSync(new Runnable() {
 			
 			@Override
 			public void run() {
+				dialogEditText.setText(tagName);
 				dialogPostiveButton.performClick();
 			}
 		});
@@ -216,6 +215,7 @@ public class ManageTagActivityTests extends ActivityInstrumentationTestCase2<Man
 				done.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 	}
 }
 

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ManageTagsTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ManageTagsTest.java
@@ -43,10 +43,10 @@ public class ManageTagsTest extends ActivityInstrumentationTestCase2<ManageTagAc
 		assertEquals(tag, (Tag)manageTagsListView.getItemAtPosition(0));
 		assertTrue(tagController.getTagList().size() == 1);
 		assertTrue(manageTagsListView.getCount() == 1);	
+		
+		instrumentation.waitForIdleSync();
 	}
 	
-	
-
 	private Tag addTagToTagList(final Tag tag) {
 		instrumentation.runOnMainSync(new Runnable() {
 

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/MapViewTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/MapViewTest.java
@@ -44,7 +44,10 @@ public class MapViewTest extends ActivityInstrumentationTestCase2<MapViewActivit
 	
 	protected void setUp() throws Exception {
 		super.setUp();
-		instrumentation = getInstrumentation();
+		// FIXME: #187
+		//        The tests in this file pass, but they hang
+		//		  when the entire suite is run.
+		fail();
 		
 		Intent mapViewIntent = new Intent();
 		mapViewIntent.putExtra("latitude", 64.0);
@@ -52,6 +55,7 @@ public class MapViewTest extends ActivityInstrumentationTestCase2<MapViewActivit
 		mapViewIntent.putExtra("requestCode", MapViewActivity.SET_GEOLOCATION);
 		setActivityIntent(mapViewIntent);
 		
+		instrumentation = getInstrumentation();
 		mapViewActivity = getActivity();
 	}
 	
@@ -62,6 +66,7 @@ public class MapViewTest extends ActivityInstrumentationTestCase2<MapViewActivit
 				mapViewActivity.singleTapConfirmedHelper(p);
 			}
 		});
+		instrumentation.waitForIdleSync();
 		assertEquals("latitude wrong", mapViewActivity.getCoordinate().getLatitude(), p.getLatitude());
 		assertEquals("latitude wrong", mapViewActivity.getCoordinate().getLongitude(), p.getLongitude());
 		
@@ -78,6 +83,7 @@ public class MapViewTest extends ActivityInstrumentationTestCase2<MapViewActivit
 				mapViewActivity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
 			}
 		});
+		instrumentation.waitForIdleSync();
 		assertTrue(mapViewActivity.askSaveLocation(p.getLatitude(), p.getLongitude()).isShowing());
 	}
 }

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/RemoveTagFromExpenseClaim.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/RemoveTagFromExpenseClaim.java
@@ -130,6 +130,7 @@ public class RemoveTagFromExpenseClaim extends ActivityInstrumentationTestCase2<
 				done.performClick();
 			}
 		});
+		instrumentation.waitForIdleSync();
 	}
 
 }

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/TagTest.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/TagTest.java
@@ -69,6 +69,7 @@ public class TagTest extends InstrumentationTestCase {
 					}
 				}
 			});
+			instrumentation.waitForIdleSync();
 			assertEquals("failed to add a tag: " + t, 1,
 					controller.getTagCount());
 			assertEquals("added a tag incorrectly", tag, controller
@@ -84,6 +85,7 @@ public class TagTest extends InstrumentationTestCase {
 					}
 				}
 			});
+			instrumentation.waitForIdleSync();
 
 			assertEquals("failed to remove a tag: " + t,
 					controller.getTagCount(), 0);
@@ -106,6 +108,7 @@ public class TagTest extends InstrumentationTestCase {
 					}
 				}
 			});
+			instrumentation.waitForIdleSync();
 
 			// The tag list will still be empty because nothing should be added
 			assertEquals("should have discarded non-alphanumeric tag: " + s,

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ViewAllExpenseClaimsActivityTests.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ViewAllExpenseClaimsActivityTests.java
@@ -379,6 +379,7 @@ public class ViewAllExpenseClaimsActivityTests extends
 				claimsList.performItemClick(claimsList.getChildAt(0), 0, 0);
 			}
 		});
+		getInstrumentation().waitForIdleSync();
 		
 		// Get the summary activity
 		summaryActivity = (TabbedSummaryClaimantActivity) getInstrumentation().waitForMonitorWithTimeout(summaryMonitor, 1000);

--- a/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ViewAllExpenseClaimsActivityTests.java
+++ b/ShinyExpenseTrackerTests/src/ca/ualberta/cs/shinyexpensetracker/test/ViewAllExpenseClaimsActivityTests.java
@@ -48,6 +48,7 @@ import ca.ualberta.cs.shinyexpensetracker.models.ExpenseClaim;
 import ca.ualberta.cs.shinyexpensetracker.models.ExpenseClaimList;
 import ca.ualberta.cs.shinyexpensetracker.models.Tag;
 import ca.ualberta.cs.shinyexpensetracker.models.TagList;
+import ca.ualberta.cs.shinyexpensetracker.models.User.Type;
 import ca.ualberta.cs.shinyexpensetracker.test.mocks.MockExpenseClaimListPersister;
 
 public class ViewAllExpenseClaimsActivityTests extends
@@ -314,9 +315,9 @@ public class ViewAllExpenseClaimsActivityTests extends
 	 * See #91 for details.
 	 */
 	public void testCrashOnNewExpense() {
-		// this test is causing test runs to crash
-		// TODO: Fix it! (see GH#173)
-		fail();
+		// TabbedSummary has split in 2. We need a way
+		// to specify which one we're looking for.
+		Application.setUserType(Type.Claimant);
 		
 		// Monitor for AddExpenseClaimActivity
 		ActivityMonitor claimMonitor = getInstrumentation().addMonitor(ExpenseClaimActivity.class.getName(), null, false);
@@ -329,7 +330,13 @@ public class ViewAllExpenseClaimsActivityTests extends
 		assertEquals(true, getInstrumentation().checkMonitorHit(claimMonitor, 1));
 		
 		getInstrumentation().waitForIdleSync();
-		
+
+		// Monitor for TabbedSummaryActivity (Claimant version)
+		// This should be before the action that opens the activity is induced.
+		ActivityMonitor summaryMonitor = getInstrumentation().addMonitor(TabbedSummaryClaimantActivity.class.getName(),
+				null,
+				false);
+
 		// Fill in the data
 		createClaim.runOnUiThread(new Runnable() {
 			
@@ -350,14 +357,11 @@ public class ViewAllExpenseClaimsActivityTests extends
 				
 			}
 		});
-		
+
 		getInstrumentation().waitForIdleSync();
-		
-		// Monitor for TabbedSummaryActivity
-		ActivityMonitor summaryMonitor = getInstrumentation().addMonitor(TabbedSummaryClaimantActivity.class.getName(), null, false);
-		
+
 		// Get the summary activity
-		TabbedSummaryActivity summaryActivity = (TabbedSummaryActivity) getInstrumentation().waitForMonitorWithTimeout(summaryMonitor, 1000);
+		TabbedSummaryActivity summaryActivity = (TabbedSummaryClaimantActivity) getInstrumentation().waitForMonitorWithTimeout(summaryMonitor, 1000);
 		assertEquals(true, getInstrumentation().checkMonitorHit(summaryMonitor, 1));
 		
 		// Close the summary
@@ -377,7 +381,7 @@ public class ViewAllExpenseClaimsActivityTests extends
 		});
 		
 		// Get the summary activity
-		summaryActivity = (TabbedSummaryActivity) getInstrumentation().waitForMonitorWithTimeout(summaryMonitor, 1000);
+		summaryActivity = (TabbedSummaryClaimantActivity) getInstrumentation().waitForMonitorWithTimeout(summaryMonitor, 1000);
 		assertEquals(true, getInstrumentation().checkMonitorHit(summaryMonitor, 1));
 		
 		// Monitor for ExpenseItemActivity


### PR DESCRIPTION
#173 
#186 

Problem was two-fold:
- The monitor wasn't being set until after the action was induced in a thread (race condition).
- TabbedSummaryActivity has split into TabbedSummaryClaimantActivity and TabbedSummaryApproverActivity, but the monitor was watching for the old name.

- I could not get the MapViewTest file to do anything other than stall the suite, so I've disabled them until they can be fixed.